### PR TITLE
refactor: use jumpgen

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,17 +57,15 @@
     "type": "git",
     "url": "https://github.com/pg-nano/pg-nano.git"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "dependencies": {
     "@pg-nano/libpq": "workspace:^",
     "@pg-nano/pg-parser": "^16.1.5",
     "@pg-nano/pg-schema-diff": "^0.7.1",
     "bundle-require": "^5.0.0",
-    "chokidar": "^3.6.0",
     "debug": "^4.3.7",
     "esbuild": "^0.23.1",
+    "jumpgen": "^0.1.0",
     "string-argv": "^0.3.2"
   },
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "type": "git",
     "url": "https://github.com/pg-nano/pg-nano.git"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@pg-nano/libpq": "workspace:^",
     "@pg-nano/pg-parser": "^16.1.5",
@@ -65,7 +67,7 @@
     "bundle-require": "^5.0.0",
     "debug": "^4.3.7",
     "esbuild": "^0.23.1",
-    "jumpgen": "^0.1.0",
+    "jumpgen": "^0.1.1",
     "string-argv": "^0.3.2"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.23.1
         version: 0.23.1
       jumpgen:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       string-argv:
         specifier: ^0.3.2
         version: 0.3.2
@@ -945,8 +945,8 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  jumpgen@0.1.0:
-    resolution: {integrity: sha512-NNJBCxalWDM/gMZ3rP7LI0kKDa7L4BXGdu36noM+WvI90ZxIuHFmW3LSbncRrHgMm8988lS3an4L4PA4RRkAbA==}
+  jumpgen@0.1.1:
+    resolution: {integrity: sha512-qlOJXyZYQ2cLNpgNVTdjJuShb4454CmDzVrAMuCLoBxI14SIUNYsBWuv+nOftGgueTnWbQ8WX8ivXR5ooB/kMw==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2191,7 +2191,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jumpgen@0.1.0:
+  jumpgen@0.1.1:
     dependencies:
       chokidar: 4.0.1
       picomatch: 4.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,15 +25,15 @@ importers:
       bundle-require:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.23.1)
-      chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
       debug:
         specifier: ^4.3.7
         version: 4.3.7
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
+      jumpgen:
+        specifier: ^0.1.0
+        version: 0.1.0
       string-argv:
         specifier: ^0.3.2
         version: 0.3.2
@@ -691,6 +691,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -941,6 +945,9 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jumpgen@0.1.0:
+    resolution: {integrity: sha512-NNJBCxalWDM/gMZ3rP7LI0kKDa7L4BXGdu36noM+WvI90ZxIuHFmW3LSbncRrHgMm8988lS3an4L4PA4RRkAbA==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -1163,6 +1170,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1895,6 +1906,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
+
   chownr@1.1.4: {}
 
   color-convert@2.0.1:
@@ -2176,6 +2191,11 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jumpgen@0.1.0:
+    dependencies:
+      chokidar: 4.0.1
+      picomatch: 4.0.2
+
   kleur@4.1.5: {}
 
   lilconfig@3.1.2: {}
@@ -2356,6 +2376,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   resolve-from@5.0.0: {}
 

--- a/src/node/env.ts
+++ b/src/node/env.ts
@@ -1,5 +1,4 @@
 import type { Options as BundleRequireOptions } from 'bundle-require'
-import { watch } from 'chokidar'
 import mri from 'mri'
 import path from 'node:path'
 import { Client } from 'pg-nano'
@@ -108,16 +107,6 @@ async function loadEnv(cwd: string, options: EnvOptions) {
     untrackedDir,
     schemaDir,
     verbose: options.verbose,
-    watcher: options.watch
-      ? watch([...config.schema.include, ...userConfigDependencies], {
-          cwd: root,
-          ignored: [
-            ...config.schema.exclude,
-            config.generate.pluginSqlDir,
-            '**/.pg-nano/**',
-          ],
-        })
-      : undefined,
     get client() {
       return (client ??= (async () => {
         events.emit('connecting', config.dev.connection)


### PR DESCRIPTION
This makes the dev mode more robust. For example, when changing your `pg-nano.config.ts` file, pg-nano will no longer have issues with duplicate file watchers. There's also the benefit of upgrading to Chokidar v4, which is lighter and possibly better perf.
